### PR TITLE
Replacing the utf_8 enconding with the scrub_rb shim

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    credit_card_sanitizer (0.3.1)
+    credit_card_sanitizer (0.3.2)
       luhn_checksum (~> 0.1)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     credit_card_sanitizer (0.3.4)
       luhn_checksum (~> 0.1)
+      scrub_rb (~> 1.0.1)
 
 GEM
   remote: https://rubygems.org/
@@ -17,6 +18,7 @@ GEM
     minitest-rg (5.1.0)
       minitest (~> 5.0)
     rake (10.3.1)
+    scrub_rb (1.0.1)
     thor (0.19.1)
 
 PLATFORMS

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    credit_card_sanitizer (0.3.3)
+    credit_card_sanitizer (0.3.4)
       luhn_checksum (~> 0.1)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    credit_card_sanitizer (0.3.2)
+    credit_card_sanitizer (0.3.3)
       luhn_checksum (~> 0.1)
 
 GEM

--- a/credit_card_sanitizer.gemspec
+++ b/credit_card_sanitizer.gemspec
@@ -1,4 +1,4 @@
-Gem::Specification.new "credit_card_sanitizer", '0.3.3' do |gem|
+Gem::Specification.new "credit_card_sanitizer", '0.3.4' do |gem|
   gem.authors       = ["Eric Chapweske", "Gary Grossman", "Victor Kmita"]
   gem.email         = ["ggrossman@zendesk.com"]
   gem.description   = "Credit card sanitizer"

--- a/credit_card_sanitizer.gemspec
+++ b/credit_card_sanitizer.gemspec
@@ -1,4 +1,4 @@
-Gem::Specification.new "credit_card_sanitizer", '0.3.2' do |gem|
+Gem::Specification.new "credit_card_sanitizer", '0.3.3' do |gem|
   gem.authors       = ["Eric Chapweske", "Gary Grossman", "Victor Kmita"]
   gem.email         = ["ggrossman@zendesk.com"]
   gem.description   = "Credit card sanitizer"

--- a/credit_card_sanitizer.gemspec
+++ b/credit_card_sanitizer.gemspec
@@ -1,13 +1,14 @@
-Gem::Specification.new "credit_card_sanitizer", '0.3.4' do |gem|
-  gem.authors       = ["Eric Chapweske", "Gary Grossman", "Victor Kmita"]
-  gem.email         = ["ggrossman@zendesk.com"]
-  gem.description   = "Credit card sanitizer"
-  gem.summary       = "Credit card sanitizer"
-  gem.homepage      = "https://github.com/zendesk/credit_card_sanitizer"
-  gem.license       = "Apache License Version 2.0"
+Gem::Specification.new 'credit_card_sanitizer', '0.3.4' do |gem|
+  gem.authors       = ['Eric Chapweske', 'Gary Grossman', 'Victor Kmita']
+  gem.email         = ['ggrossman@zendesk.com']
+  gem.description   = 'Credit card sanitizer'
+  gem.summary       = 'Credit card sanitizer'
+  gem.homepage      = 'https://github.com/zendesk/credit_card_sanitizer'
+  gem.license       = 'Apache License Version 2.0'
   gem.files         = `git ls-files lib`.split($\)
   gem.add_development_dependency('appraisal')
   gem.add_development_dependency('rake')
   gem.add_development_dependency('bundler')
-  gem.add_runtime_dependency("luhn_checksum", '~> 0.1')
+  gem.add_runtime_dependency('luhn_checksum', '~> 0.1')
+  gem.add_runtime_dependency('scrub_rb', '~> 1.0.1')
 end

--- a/credit_card_sanitizer.gemspec
+++ b/credit_card_sanitizer.gemspec
@@ -1,4 +1,4 @@
-Gem::Specification.new "credit_card_sanitizer", '0.3.1' do |gem|
+Gem::Specification.new "credit_card_sanitizer", '0.3.2' do |gem|
   gem.authors       = ["Eric Chapweske", "Gary Grossman", "Victor Kmita"]
   gem.email         = ["ggrossman@zendesk.com"]
   gem.description   = "Credit card sanitizer"

--- a/lib/credit_card_sanitizer.rb
+++ b/lib/credit_card_sanitizer.rb
@@ -24,7 +24,7 @@ class CreditCardSanitizer
   EXPIRATION_DATE = /\s(?:0?[1-9]|1[0-2])(?:\/|-)(?:\d{4}|\d{2})(?:\s|$)/
   LINE_NOISE = /[^\w_\n,()\/:]{,5}/
   SCHEME_OR_PLUS = /(\+|(?:[a-zA-Z][\-+.a-zA-Z\d]{,9}):\S+)/
-  NUMBERS_WITH_LINE_NOISE = /#{SCHEME_OR_PLUS}?\d(?:#{LINE_NOISE}\d#{LINE_NOISE}){10,17}\d/
+  NUMBERS_WITH_LINE_NOISE = /#{SCHEME_OR_PLUS}?\d(?:#{LINE_NOISE}\d#{LINE_NOISE}){10,18}\d/
 
   attr_reader :replacement_token, :expose_first, :expose_last
 

--- a/lib/credit_card_sanitizer.rb
+++ b/lib/credit_card_sanitizer.rb
@@ -23,8 +23,8 @@ class CreditCardSanitizer
   VALID_COMPANY_PREFIXES = Regexp.union(*CARD_COMPANIES.values)
   EXPIRATION_DATE = /\s(?:0?[1-9]|1[0-2])(?:\/|-)(?:\d{4}|\d{2})(?:\s|$)/
   LINE_NOISE = /[^\w_\n,()\/:]{,5}/
-  SCHEME = /((?:[a-zA-Z][\-+.a-zA-Z\d]{,9}):\S+)/
-  NUMBERS_WITH_LINE_NOISE = /#{SCHEME}?\d(?:#{LINE_NOISE}\d#{LINE_NOISE}){10,17}\d/
+  SCHEME_OR_PLUS = /(\+|(?:[a-zA-Z][\-+.a-zA-Z\d]{,9}):\S+)/
+  NUMBERS_WITH_LINE_NOISE = /#{SCHEME_OR_PLUS}?\d(?:#{LINE_NOISE}\d#{LINE_NOISE}){10,17}\d/
 
   attr_reader :replacement_token, :expose_first, :expose_last
 

--- a/lib/credit_card_sanitizer.rb
+++ b/lib/credit_card_sanitizer.rb
@@ -59,7 +59,7 @@ class CreditCardSanitizer
   # Returns a String of the redacted text if a credit card number was detected.
   # Returns nil if no credit card numbers were detected.
   def sanitize!(text)
-    to_utf8!(text)
+    text.scrub!('�')
 
     redacted = nil
 
@@ -130,20 +130,5 @@ class CreditCardSanitizer
     text.gsub!(EXPIRATION_DATE) { |expiration_date| "#{expiration_date_boundary}#{expiration_date}#{expiration_date_boundary}"  }
     yield
     text.gsub!(expiration_date_boundary, '')
-  end
-
-  if ''.respond_to?(:scrub)
-    def to_utf8!(str)
-      str.force_encoding(Encoding::UTF_8)
-      str.scrub! unless str.valid_encoding?
-    end
-  else
-    def to_utf8!(str)
-      str.force_encoding(Encoding::UTF_8)
-      unless str.valid_encoding?
-        str.encode!(Encoding::UTF_16, :invalid => :replace, :replace => '�')
-        str.encode!(Encoding::UTF_8, Encoding::UTF_16)
-      end
-    end
   end
 end

--- a/lib/credit_card_sanitizer.rb
+++ b/lib/credit_card_sanitizer.rb
@@ -24,7 +24,7 @@ class CreditCardSanitizer
   EXPIRATION_DATE = /\s(?:0?[1-9]|1[0-2])(?:\/|-)(?:\d{4}|\d{2})(?:\s|$)/
   LINE_NOISE = /[^\w_\n,()\/:]{,5}/
   SCHEME_OR_PLUS = /(\+|(?:[a-zA-Z][\-+.a-zA-Z\d]{,9}):\S+)/
-  NUMBERS_WITH_LINE_NOISE = /#{SCHEME_OR_PLUS}?\d(?:#{LINE_NOISE}\d#{LINE_NOISE}){10,18}\d/
+  NUMBERS_WITH_LINE_NOISE = /#{SCHEME_OR_PLUS}?\d(?:#{LINE_NOISE}\d){10,18}/
 
   attr_reader :replacement_token, :expose_first, :expose_last
 

--- a/test/credit_card_sanitizer_test.rb
+++ b/test/credit_card_sanitizer_test.rb
@@ -90,6 +90,13 @@ class CreditCardSanitizerTest < MiniTest::Test
         assert_nil @sanitizer.sanitize!("(http://support.zendesk.com/tickets/4111111111111111)")
       end
 
+      it "does not sanitize credit card numbers that start with +" do
+        assert_nil @sanitizer.sanitize!("+4111111111111111")
+        assert_nil @sanitizer.sanitize!("blah blah  +4111111111111111.json")
+        assert_nil @sanitizer.sanitize!("\"+4111111111111111\"")
+        assert_nil @sanitizer.sanitize!("(+4111111111111111)")
+      end
+
       it "does not mutate the text when there is a url" do
         url = "http://support.zendesk.com/tickets/4111111111111111"
         assert_nil @sanitizer.sanitize!(url)

--- a/test/credit_card_sanitizer_test.rb
+++ b/test/credit_card_sanitizer_test.rb
@@ -118,6 +118,11 @@ class CreditCardSanitizerTest < MiniTest::Test
         assert_equal "4111 11▇▇ ▇▇▇▇ 1111 3-2015", @sanitizer.sanitize!("4111 1111 1111 1111 3-2015")
         assert_equal "4111 11▇▇ ▇▇▇▇ 1111 03-2015 asdbhasd", @sanitizer.sanitize!("4111 1111 1111 1111 03-2015 asdbhasd")
       end
+
+      it "does not sanitize a credit card number immediately followed by digits" do
+        assert_nil @sanitizer.sanitize!("41111111111111112")
+        assert_nil @sanitizer.sanitize!("411111111111111123456789")
+      end
     end
 
     describe "#parameter_filter" do

--- a/test/credit_card_sanitizer_test.rb
+++ b/test/credit_card_sanitizer_test.rb
@@ -30,6 +30,13 @@ class CreditCardSanitizerTest < MiniTest::Test
         assert_equal 'My cc is 411111▇▇▇▇▇▇1111, I repeat, 411111▇▇▇▇▇▇1111', @sanitizer.sanitize!('My cc is 4111111111111111, I repeat, 4111111111111111')
       end
 
+      it "finishes in a reasonable amount of time with spacey input" do
+        input = "Hello  0      0      0     14     20      1      1     20     34      9      1      0      0      0      0      0"
+        Timeout.timeout(3) do
+          assert_nil @sanitizer.sanitize!(input)
+        end
+      end
+
       it "has a configurable replacement character" do
         sanitizer = CreditCardSanitizer.new(replacement_token: '*')
         assert_equal 'Hello 4111 11**** **111 1 there', sanitizer.sanitize!('Hello 4111 111111 11111 1 there')


### PR DESCRIPTION
This PR will replace the to_uf8 logic with the scrub_rb shim that seems to work well on all platforms.

/cc @ggrossman @grosser
