### PR TITLE
Remove the period (.) as a valid line noise character

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 bundler_args: ""
 rvm:
-  - 1.9.3
   - 2.0.0
-  - 2.1.2
+  - 2.1.7
+  - 2.2.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    credit_card_sanitizer (0.3.4)
+    credit_card_sanitizer (0.3.5)
       luhn_checksum (~> 0.1)
       scrub_rb (~> 1.0.1)
 
@@ -32,3 +32,6 @@ DEPENDENCIES
   minitest
   minitest-rg
   rake
+
+BUNDLED WITH
+   1.10.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    credit_card_sanitizer (0.3.1)
+    credit_card_sanitizer (0.3.2)
       luhn_checksum (~> 0.1)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    credit_card_sanitizer (0.3.5)
+    credit_card_sanitizer (0.3.6)
       luhn_checksum (~> 0.1)
       scrub_rb (~> 1.0.1)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     credit_card_sanitizer (0.3.4)
       luhn_checksum (~> 0.1)
+      scrub_rb (~> 1.0.1)
 
 GEM
   remote: https://rubygems.org/
@@ -17,6 +18,7 @@ GEM
     minitest-rg (5.1.0)
       minitest (~> 5.0)
     rake (10.3.1)
+    scrub_rb (1.0.1)
     thor (0.19.1)
 
 PLATFORMS

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    credit_card_sanitizer (0.3.3)
+    credit_card_sanitizer (0.3.4)
       luhn_checksum (~> 0.1)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    credit_card_sanitizer (0.3.7)
+    credit_card_sanitizer (0.4.0)
       luhn_checksum (~> 0.1)
       scrub_rb (~> 1.0.1)
 
@@ -34,4 +34,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    credit_card_sanitizer (0.4.0)
+    credit_card_sanitizer (0.5.0)
       luhn_checksum (~> 0.1)
       scrub_rb (~> 1.0.1)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    credit_card_sanitizer (0.3.6)
+    credit_card_sanitizer (0.3.7)
       luhn_checksum (~> 0.1)
       scrub_rb (~> 1.0.1)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    credit_card_sanitizer (0.3.2)
+    credit_card_sanitizer (0.3.3)
       luhn_checksum (~> 0.1)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -25,10 +25,12 @@ text == "Hello my card is 4111 11▇▇ ▇▇▇▇ 1111 maybe you should not s
 
 ### Configuration
 
-`replacement_token`: The character used to replace digits of the credit number.  The default is `▇`.
-`expose_first`: The number of leading digits of the credit card number to leave intact. The default is `6`.
-`expose_last`: The number of trailing digits of the credit card number to leave intact. The default is `4`.
-`use_groupings`: Use known card number groupings to reduce false positives. The default is `false`.
+Name                | Description
+------------------- | -----------
+`replacement_token` | The character used to replace digits of the credit number.  The default is `▇`.
+`expose_first`      | The number of leading digits of the credit card number to leave intact. The default is `6`.
+`expose_last`       | The number of trailing digits of the credit card number to leave intact. The default is `4`.
+`use_groupings`     | Use known card number groupings to reduce false positives. The default is `false`.
 
 ### Default Replacement Level
 

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ number is stored in multiple places on your systems, it can be hard to get rid o
 Removal of credit card information is an important element in [PCI compliance](https://www.pcisecuritystandards.org).
 
 `credit_card_sanitizer` scans text for credit card numbers by applying the Luhn checksum algorithm,
-implemented by the [luhn_checksum](https://github.com/eac/luhn_checksum) gem, and by validating the number has a proper
-credit card number prefix. Numbers in text that appear to be valid credit card numbers are "sanitized" by replacing
-some or all of the digits with a replacement character.
+implemented by the [luhn_checksum](https://github.com/zendesk/luhn_checksum) gem, and by validating that the
+number matches a known credit card number pattern. Numbers in text that appear to be valid credit card numbers
+are "sanitized" by replacing some or all of the digits with a replacement character.
 
 Example:
 
-```Ruby
+```ruby
 text = "Hello my card is 4111 1111 1111 1111  maybe you should not store that in your database!"
 CreditCardSanitizer.new(replacement_character: '▇').sanitizer.sanitize!(text)
 text == "Hello my card is 4111 11▇▇ ▇▇▇▇ 1111 maybe you should not store that in your database!"
@@ -28,6 +28,7 @@ text == "Hello my card is 4111 11▇▇ ▇▇▇▇ 1111 maybe you should not s
 `replacement_token`: The character used to replace digits of the credit number.  The default is `▇`.
 `expose_first`: The number of leading digits of the credit card number to leave intact. The default is `6`.
 `expose_last`: The number of trailing digits of the credit card number to leave intact. The default is `4`.
+`use_groupings`: Use known card number groupings to reduce false positives. The default is `false`.
 
 ### Default Replacement Level
 
@@ -40,7 +41,7 @@ is no longer considered credit card data under the PCI standard.
 ### Line noise
 
 `credit_card_sanitizer` allows for "line noise" between the digits of a credit card number.  Line noise
-is any sequence of non-numeric characters. For example, all of the following numbers will be sanitized
+is a sequence of non-numeric characters. For example, all of the following numbers will be sanitized
 successfully:
 
 ```
@@ -49,12 +50,33 @@ successfully:
 4111*1111***1111*****1111
 ```
 
+We occasionally tweak the regular expression that defines line noise to reduce the rate of false positives.
+
 ### Card number length and valid prefixes
 
 Numbers are sanitized if they are a minimum of 12 digits long and a maximum of 19 digits long, and have a proper
 prefix that matches an IIN range of an issuing network like Visa or MasterCard
-(https://en.wikipedia.org/wiki/Primary_Account_Number). We have shamelessly taken the regex used in [active_merchant](https://github.com/Shopify/active_merchant/blob/master/lib/active_merchant/billing/credit_card_methods.rb#L5-L18)
+(https://en.wikipedia.org/wiki/Primary_Account_Number). We have borrowed the regex used in [active_merchant](https://github.com/Shopify/active_merchant/blob/master/lib/active_merchant/billing/credit_card_methods.rb#L5-L18)
 to validate these prefixes.
+
+### Card number groupings
+
+Some false positives are inevitable when using this gem, and they can be a nuisance.
+
+To reduce the false positive rate, you can specify `use_groupings: true` when configuring the sanitizer. This causes
+the sanitizer to pay attention to the groupings of numbers as it scans them, only sanitizing numbers that
+
+* have a valid Luhn checksum
+* match a pattern for a known credit card type
+* are either a single contiguous string of digits, or digits in groups matching that known credit card type
+
+Example: Visa cards are 4 groups of 4 digits, `XXXX XXXX XXXX XXXX`. `4111 1111 1111 1111` is a number that matches
+the Visa pattern (starts with `4`) and passes Luhn checksum.
+
+With `use_groupings: true`, the sanitizer would sanitize `4111111111111111` and `4111 1111 1111 1111` but not
+`41 11 11 11 11 11 11 11` or `41111111 11111111`.
+
+With `use_groupings: false`, the sanitizer would sanitize all of the above strings.
 
 ### Rails filtering parameters
 

--- a/credit_card_sanitizer.gemspec
+++ b/credit_card_sanitizer.gemspec
@@ -1,4 +1,4 @@
-Gem::Specification.new 'credit_card_sanitizer', '0.3.7' do |gem|
+Gem::Specification.new 'credit_card_sanitizer', '0.4.0' do |gem|
   gem.authors       = ['Eric Chapweske', 'Gary Grossman', 'Victor Kmita']
   gem.email         = ['ggrossman@zendesk.com']
   gem.description   = 'Credit card sanitizer'

--- a/credit_card_sanitizer.gemspec
+++ b/credit_card_sanitizer.gemspec
@@ -1,4 +1,4 @@
-Gem::Specification.new "credit_card_sanitizer", '0.3.3' do |gem|
+Gem::Specification.new "credit_card_sanitizer", '0.3.4' do |gem|
   gem.authors       = ["Eric Chapweske", "Gary Grossman", "Victor Kmita"]
   gem.email         = ["ggrossman@zendesk.com"]
   gem.description   = "Credit card sanitizer"

--- a/credit_card_sanitizer.gemspec
+++ b/credit_card_sanitizer.gemspec
@@ -1,4 +1,4 @@
-Gem::Specification.new 'credit_card_sanitizer', '0.4.0' do |gem|
+Gem::Specification.new 'credit_card_sanitizer', '0.5.0' do |gem|
   gem.authors       = ['Eric Chapweske', 'Gary Grossman', 'Victor Kmita']
   gem.email         = ['ggrossman@zendesk.com']
   gem.description   = 'Credit card sanitizer'

--- a/credit_card_sanitizer.gemspec
+++ b/credit_card_sanitizer.gemspec
@@ -1,4 +1,4 @@
-Gem::Specification.new 'credit_card_sanitizer', '0.3.6' do |gem|
+Gem::Specification.new 'credit_card_sanitizer', '0.3.7' do |gem|
   gem.authors       = ['Eric Chapweske', 'Gary Grossman', 'Victor Kmita']
   gem.email         = ['ggrossman@zendesk.com']
   gem.description   = 'Credit card sanitizer'

--- a/credit_card_sanitizer.gemspec
+++ b/credit_card_sanitizer.gemspec
@@ -1,4 +1,4 @@
-Gem::Specification.new "credit_card_sanitizer", '0.3.2' do |gem|
+Gem::Specification.new "credit_card_sanitizer", '0.3.3' do |gem|
   gem.authors       = ["Eric Chapweske", "Gary Grossman", "Victor Kmita"]
   gem.email         = ["ggrossman@zendesk.com"]
   gem.description   = "Credit card sanitizer"

--- a/credit_card_sanitizer.gemspec
+++ b/credit_card_sanitizer.gemspec
@@ -1,4 +1,4 @@
-Gem::Specification.new 'credit_card_sanitizer', '0.3.5' do |gem|
+Gem::Specification.new 'credit_card_sanitizer', '0.3.6' do |gem|
   gem.authors       = ['Eric Chapweske', 'Gary Grossman', 'Victor Kmita']
   gem.email         = ['ggrossman@zendesk.com']
   gem.description   = 'Credit card sanitizer'

--- a/credit_card_sanitizer.gemspec
+++ b/credit_card_sanitizer.gemspec
@@ -1,13 +1,14 @@
-Gem::Specification.new "credit_card_sanitizer", '0.3.4' do |gem|
-  gem.authors       = ["Eric Chapweske", "Gary Grossman", "Victor Kmita"]
-  gem.email         = ["ggrossman@zendesk.com"]
-  gem.description   = "Credit card sanitizer"
-  gem.summary       = "Credit card sanitizer"
-  gem.homepage      = "https://github.com/zendesk/credit_card_sanitizer"
-  gem.license       = "Apache License Version 2.0"
+Gem::Specification.new 'credit_card_sanitizer', '0.3.4' do |gem|
+  gem.authors       = ['Eric Chapweske', 'Gary Grossman', 'Victor Kmita']
+  gem.email         = ['ggrossman@zendesk.com']
+  gem.description   = 'Credit card sanitizer'
+  gem.summary       = 'Credit card sanitizer'
+  gem.homepage      = 'https://github.com/zendesk/credit_card_sanitizer'
+  gem.license       = 'Apache License Version 2.0'
   gem.files         = `git ls-files lib`.split($\)
   gem.add_development_dependency('appraisal')
   gem.add_development_dependency('rake')
   gem.add_development_dependency('bundler')
-  gem.add_runtime_dependency("luhn_checksum", '~> 0.1')
+  gem.add_runtime_dependency('luhn_checksum', '~> 0.1')
+  gem.add_runtime_dependency('scrub_rb', '~> 1.0.1')
 end

--- a/credit_card_sanitizer.gemspec
+++ b/credit_card_sanitizer.gemspec
@@ -1,4 +1,4 @@
-Gem::Specification.new 'credit_card_sanitizer', '0.3.4' do |gem|
+Gem::Specification.new 'credit_card_sanitizer', '0.3.5' do |gem|
   gem.authors       = ['Eric Chapweske', 'Gary Grossman', 'Victor Kmita']
   gem.email         = ['ggrossman@zendesk.com']
   gem.description   = 'Credit card sanitizer'

--- a/credit_card_sanitizer.gemspec
+++ b/credit_card_sanitizer.gemspec
@@ -1,4 +1,4 @@
-Gem::Specification.new "credit_card_sanitizer", '0.3.1' do |gem|
+Gem::Specification.new "credit_card_sanitizer", '0.3.2' do |gem|
   gem.authors       = ["Eric Chapweske", "Gary Grossman", "Victor Kmita"]
   gem.email         = ["ggrossman@zendesk.com"]
   gem.description   = "Credit card sanitizer"

--- a/lib/credit_card_sanitizer.rb
+++ b/lib/credit_card_sanitizer.rb
@@ -24,7 +24,7 @@ class CreditCardSanitizer
   EXPIRATION_DATE = /\s(?:0?[1-9]|1[0-2])(?:\/|-)(?:\d{4}|\d{2})(?:\s|$)/
   LINE_NOISE = /[^\w_\n,()\/:]{,5}/
   SCHEME_OR_PLUS = /(\+|(?:[a-zA-Z][\-+.a-zA-Z\d]{,9}):\S+)/
-  NUMBERS_WITH_LINE_NOISE = /#{SCHEME_OR_PLUS}?\d(?:#{LINE_NOISE}\d#{LINE_NOISE}){10,17}\d/
+  NUMBERS_WITH_LINE_NOISE = /#{SCHEME_OR_PLUS}?\d(?:#{LINE_NOISE}\d#{LINE_NOISE}){10,18}\d/
 
   attr_reader :replacement_token, :expose_first, :expose_last
 

--- a/lib/credit_card_sanitizer.rb
+++ b/lib/credit_card_sanitizer.rb
@@ -60,6 +60,7 @@ class CreditCardSanitizer
   # Returns a String of the redacted text if a credit card number was detected.
   # Returns nil if no credit card numbers were detected.
   def sanitize!(text)
+    text.force_encoding(Encoding::UTF_8)
     text.scrub!('�')
 
     redacted = nil

--- a/lib/credit_card_sanitizer.rb
+++ b/lib/credit_card_sanitizer.rb
@@ -23,8 +23,8 @@ class CreditCardSanitizer
   VALID_COMPANY_PREFIXES = Regexp.union(*CARD_COMPANIES.values)
   EXPIRATION_DATE = /\s(?:0?[1-9]|1[0-2])(?:\/|-)(?:\d{4}|\d{2})(?:\s|$)/
   LINE_NOISE = /[^\w_\n,()\/:]{,5}/
-  SCHEME = /((?:[a-zA-Z][\-+.a-zA-Z\d]{,9}):\S+)/
-  NUMBERS_WITH_LINE_NOISE = /#{SCHEME}?\d(?:#{LINE_NOISE}\d#{LINE_NOISE}){10,17}\d/
+  SCHEME_OR_PLUS = /(\+|(?:[a-zA-Z][\-+.a-zA-Z\d]{,9}):\S+)/
+  NUMBERS_WITH_LINE_NOISE = /#{SCHEME_OR_PLUS}?\d(?:#{LINE_NOISE}\d#{LINE_NOISE}){10,17}\d/
 
   attr_reader :replacement_token, :expose_first, :expose_last
 

--- a/lib/credit_card_sanitizer.rb
+++ b/lib/credit_card_sanitizer.rb
@@ -39,7 +39,7 @@ class CreditCardSanitizer
 
   VALID_COMPANY_PREFIXES = Regexp.union(*CARD_COMPANIES.values)
   EXPIRATION_DATE = /\s(?:0?[1-9]|1[0-2])(?:\/|-)(?:\d{4}|\d{2})(?:\s|$)/
-  LINE_NOISE_CHAR = /[^\w_\n,()\/:;<>]/
+  LINE_NOISE_CHAR = /[^\w_\n,().\/:;<>]/
   LINE_NOISE = /#{LINE_NOISE_CHAR}{,5}/
   NONEMPTY_LINE_NOISE = /#{LINE_NOISE_CHAR}{1,5}/
   SCHEME_OR_PLUS = /((?:&#43;|\+)|(?:[a-zA-Z][\-+.a-zA-Z\d]{,9}):\S+)/

--- a/lib/credit_card_sanitizer.rb
+++ b/lib/credit_card_sanitizer.rb
@@ -23,7 +23,7 @@ class CreditCardSanitizer
   }
   VALID_COMPANY_PREFIXES = Regexp.union(*CARD_COMPANIES.values)
   EXPIRATION_DATE = /\s(?:0?[1-9]|1[0-2])(?:\/|-)(?:\d{4}|\d{2})(?:\s|$)/
-  LINE_NOISE = /[^\w_\n,()\/:;]{,5}/
+  LINE_NOISE = /[^\w_\n,()\/:;<>]{,5}/
   SCHEME_OR_PLUS = /((?:&#43;|\+)|(?:[a-zA-Z][\-+.a-zA-Z\d]{,9}):\S+)/
   NUMBERS_WITH_LINE_NOISE = /#{SCHEME_OR_PLUS}?\d(?:#{LINE_NOISE}\d){10,18}/
 

--- a/lib/credit_card_sanitizer.rb
+++ b/lib/credit_card_sanitizer.rb
@@ -2,6 +2,7 @@
 
 require 'luhn_checksum'
 require 'securerandom'
+require 'scrub_rb'
 
 class CreditCardSanitizer
 

--- a/lib/credit_card_sanitizer.rb
+++ b/lib/credit_card_sanitizer.rb
@@ -24,7 +24,7 @@ class CreditCardSanitizer
   VALID_COMPANY_PREFIXES = Regexp.union(*CARD_COMPANIES.values)
   EXPIRATION_DATE = /\s(?:0?[1-9]|1[0-2])(?:\/|-)(?:\d{4}|\d{2})(?:\s|$)/
   LINE_NOISE = /[^\w_\n,()\/:]{,5}/
-  SCHEME_OR_PLUS = /(\+|(?:[a-zA-Z][\-+.a-zA-Z\d]{,9}):\S+)/
+  SCHEME_OR_PLUS = /((?:&#43;|\+)|(?:[a-zA-Z][\-+.a-zA-Z\d]{,9}):\S+)/
   NUMBERS_WITH_LINE_NOISE = /#{SCHEME_OR_PLUS}?\d(?:#{LINE_NOISE}\d){10,18}/
 
   attr_reader :replacement_token, :expose_first, :expose_last

--- a/lib/credit_card_sanitizer.rb
+++ b/lib/credit_card_sanitizer.rb
@@ -59,7 +59,7 @@ class CreditCardSanitizer
   # Returns a String of the redacted text if a credit card number was detected.
   # Returns nil if no credit card numbers were detected.
   def sanitize!(text)
-    to_utf8!(text)
+    text.scrub!('�')
 
     redacted = nil
 
@@ -130,20 +130,5 @@ class CreditCardSanitizer
     text.gsub!(EXPIRATION_DATE) { |expiration_date| "#{expiration_date_boundary}#{expiration_date}#{expiration_date_boundary}"  }
     yield
     text.gsub!(expiration_date_boundary, '')
-  end
-
-  if ''.respond_to?(:scrub)
-    def to_utf8!(str)
-      str.force_encoding(Encoding::UTF_8)
-      str.scrub! unless str.valid_encoding?
-    end
-  else
-    def to_utf8!(str)
-      str.force_encoding(Encoding::UTF_8)
-      unless str.valid_encoding?
-        str.encode!(Encoding::UTF_16, :invalid => :replace, :replace => '�')
-        str.encode!(Encoding::UTF_8, Encoding::UTF_16)
-      end
-    end
   end
 end

--- a/lib/credit_card_sanitizer.rb
+++ b/lib/credit_card_sanitizer.rb
@@ -23,7 +23,7 @@ class CreditCardSanitizer
   }
   VALID_COMPANY_PREFIXES = Regexp.union(*CARD_COMPANIES.values)
   EXPIRATION_DATE = /\s(?:0?[1-9]|1[0-2])(?:\/|-)(?:\d{4}|\d{2})(?:\s|$)/
-  LINE_NOISE = /[^\w_\n,()\/:]{,5}/
+  LINE_NOISE = /[^\w_\n,()\/:;]{,5}/
   SCHEME_OR_PLUS = /((?:&#43;|\+)|(?:[a-zA-Z][\-+.a-zA-Z\d]{,9}):\S+)/
   NUMBERS_WITH_LINE_NOISE = /#{SCHEME_OR_PLUS}?\d(?:#{LINE_NOISE}\d){10,18}/
 

--- a/lib/credit_card_sanitizer.rb
+++ b/lib/credit_card_sanitizer.rb
@@ -21,9 +21,27 @@ class CreditCardSanitizer
     'forbrugsforeningen' => /^600722\d{10}$/,
     'laser'              => /^(6304|6706|6709|6771(?!89))\d{8}(\d{4}|\d{6,7})?$/
   }
+
+  CARD_NUMBER_GROUPINGS = {
+    'visa'               => [[4, 4, 4, 4]],
+    'master'             => [[4, 4, 4, 4]],
+    'discover'           => [[4, 4, 4, 4]],
+    'american_express'   => [[4, 6, 5]],
+    'diners_club'        => [[4, 6, 4]],
+    'jcb'                => [[4, 4, 4, 4]],
+    'switch'             => [[4, 4, 4, 4]],
+    'solo'               => [[4, 4, 4, 4]],
+    'dankort'            => [[4, 4, 4, 4]],
+    'maestro'            => [[4], [5]],
+    'forbrugsforeningen' => [[4, 4, 4, 4]],
+    'laser'              => [[4, 4, 4, 4]]
+  }
+
   VALID_COMPANY_PREFIXES = Regexp.union(*CARD_COMPANIES.values)
   EXPIRATION_DATE = /\s(?:0?[1-9]|1[0-2])(?:\/|-)(?:\d{4}|\d{2})(?:\s|$)/
-  LINE_NOISE = /[^\w_\n,()\/:;<>]{,5}/
+  LINE_NOISE_CHAR = /[^\w_\n,()\/:;<>]/
+  LINE_NOISE = /#{LINE_NOISE_CHAR}{,5}/
+  NONEMPTY_LINE_NOISE = /#{LINE_NOISE_CHAR}{1,5}/
   SCHEME_OR_PLUS = /((?:&#43;|\+)|(?:[a-zA-Z][\-+.a-zA-Z\d]{,9}):\S+)/
   NUMBERS_WITH_LINE_NOISE = /#{SCHEME_OR_PLUS}?\d(?:#{LINE_NOISE}\d){10,18}/
 
@@ -68,14 +86,16 @@ class CreditCardSanitizer
     without_expiration(text) do
       text.gsub!(NUMBERS_WITH_LINE_NOISE) do |match|
         next match if $1
+
+        @match = match
         @numbers = match.tr('^0-9', '')
 
         if valid_numbers?
           redacted = true
-          redact_numbers!(match)
+          redact_numbers!
         end
 
-        match
+        @match
       end
     end
 
@@ -109,12 +129,31 @@ class CreditCardSanitizer
     !!(numbers =~ VALID_COMPANY_PREFIXES)
   end
 
-  def valid_numbers?
-    LuhnChecksum.valid?(@numbers) && valid_prefix?(@numbers)
+  def find_company
+    CARD_COMPANIES.each do |company, pattern|
+      return company if @numbers =~ pattern
+    end
   end
 
-  def redact_numbers!(text)
-    text.gsub!(/\d/).with_index do |number, digit_index|
+  def valid_grouping?
+    if company = find_company
+      groupings = @match.split(NONEMPTY_LINE_NOISE).map(&:length)
+      return true if groupings.length == 1
+      if company_groupings = CARD_NUMBER_GROUPINGS[company]
+        company_groupings.each do |company_grouping|
+          return true if groupings.take(company_grouping.length) == company_grouping
+        end
+      end
+    end
+    false
+  end
+
+  def valid_numbers?
+    LuhnChecksum.valid?(@numbers) && valid_prefix?(@numbers) && valid_grouping?
+  end
+
+  def redact_numbers!
+    @match.gsub!(/\d/).with_index do |number, digit_index|
       if within_redaction_range?(digit_index)
         replacement_token
       else

--- a/lib/credit_card_sanitizer.rb
+++ b/lib/credit_card_sanitizer.rb
@@ -24,7 +24,7 @@ class CreditCardSanitizer
   EXPIRATION_DATE = /\s(?:0?[1-9]|1[0-2])(?:\/|-)(?:\d{4}|\d{2})(?:\s|$)/
   LINE_NOISE = /[^\w_\n,()\/:]{,5}/
   SCHEME_OR_PLUS = /(\+|(?:[a-zA-Z][\-+.a-zA-Z\d]{,9}):\S+)/
-  NUMBERS_WITH_LINE_NOISE = /#{SCHEME_OR_PLUS}?\d(?:#{LINE_NOISE}\d#{LINE_NOISE}){10,18}\d/
+  NUMBERS_WITH_LINE_NOISE = /#{SCHEME_OR_PLUS}?\d(?:#{LINE_NOISE}\d){10,18}/
 
   attr_reader :replacement_token, :expose_first, :expose_last
 

--- a/test/credit_card_sanitizer_test.rb
+++ b/test/credit_card_sanitizer_test.rb
@@ -51,11 +51,11 @@ class CreditCardSanitizerTest < MiniTest::Test
       end
 
       it "has configurable replacement digits" do
-        @sanitizer = CreditCardSanitizer.new(expose_first: 0, expose_last: 4)
-        assert_equal 'Hello ▇▇▇▇ ▇▇▇▇ ▇▇▇▇ 1111 there',     @sanitizer.sanitize!('Hello 4111 1111 1111 1111 there')
-        assert_equal 'Hello ▇▇▇▇ ▇▇▇▇ ▇▇▇▇ 1111 z 3 there', @sanitizer.sanitize!('Hello 4111 1111 1111 1111 z 3 there')
-        assert_equal 'Hello ▇▇▇▇-▇▇▇▇-▇▇▇▇-1111 there', @sanitizer.sanitize!('Hello 4111-1111-1111-1111 there')
-        assert_equal 'Hello ▇▇▇▇▇▇▇▇▇▇▇▇1111 there', @sanitizer.sanitize!('Hello 4111111111111111 there')
+        sanitizer = CreditCardSanitizer.new(expose_first: 0, expose_last: 4)
+        assert_equal 'Hello ▇▇▇▇ ▇▇▇▇ ▇▇▇▇ 1111 there', sanitizer.sanitize!('Hello 4111 1111 1111 1111 there')
+        assert_equal 'Hello ▇▇▇▇ ▇▇▇▇ ▇▇▇▇ 1111 z 3 there', sanitizer.sanitize!('Hello 4111 1111 1111 1111 z 3 there')
+        assert_equal 'Hello ▇▇▇▇-▇▇▇▇-▇▇▇▇-1111 there', sanitizer.sanitize!('Hello 4111-1111-1111-1111 there')
+        assert_equal 'Hello ▇▇▇▇▇▇▇▇▇▇▇▇1111 there', sanitizer.sanitize!('Hello 4111111111111111 there')
       end
 
       it "does not sanitize invalid credit card numbers" do
@@ -153,47 +153,68 @@ class CreditCardSanitizerTest < MiniTest::Test
       end
 
       describe "card number grouping" do
-        it "sanitizes visa card grouped 4-4-4-4" do
-          assert_equal 'Hello 4111 11▇▇ ▇▇▇▇ 1111 there', @sanitizer.sanitize!('Hello 4111 1111 1111 1111 there')
+        describe "use_groupings is false" do
+          before do
+            refute @sanitizer.use_groupings
+          end
+
+          it "sanitizes cards grouped any which way" do
+            assert_equal 'Hello 4111 11▇▇ ▇▇▇▇ 1111 there', @sanitizer.sanitize!('Hello 4111 1111 1111 1111 there')
+            assert_equal 'Hello 41 11 11 ▇▇ ▇▇ ▇▇ 11 11 there', @sanitizer.sanitize!('Hello 41 11 11 11 11 11 11 11 there')
+            assert_equal 'Hello 411111▇▇▇▇▇▇1111 there', @sanitizer.sanitize!('Hello 4111111111111111 there')
+            assert_equal 'Hello 3782 82▇▇▇▇ ▇0005 there', @sanitizer.sanitize!('Hello 3782 822463 10005 there')
+            assert_equal 'Hello 378282▇▇▇▇▇0005 there', @sanitizer.sanitize!('Hello 378282246310005 there')
+            assert_equal 'Hello 37 828 2▇▇▇▇▇0 005 there', @sanitizer.sanitize!('Hello 37 828 2246310 005 there')
+          end
         end
 
-        it "does not sanitize visa card grouped oddly" do
-          assert_nil @sanitizer.sanitize!('Hello 41 11 11 11 11 11 11 11 there')
-        end
+        describe "use_groupings is true" do
+          before do
+            @sanitizer = CreditCardSanitizer.new(use_groupings: true)
+          end
 
-        it "sanitizes mastercard grouped 4-4-4-4" do
-          assert_equal 'Hello 5555 55▇▇ ▇▇▇▇ 4444 there', @sanitizer.sanitize!('Hello 5555 5555 5555 4444 there')
-        end
+          it "sanitizes visa card grouped 4-4-4-4" do
+            assert_equal 'Hello 4111 11▇▇ ▇▇▇▇ 1111 there', @sanitizer.sanitize!('Hello 4111 1111 1111 1111 there')
+          end
 
-        it "does not sanitize mastercard grouped oddly" do
-          assert_nil @sanitizer.sanitize!('Hello 55555 55555 554444 there')
-        end
+          it "does not sanitize visa card grouped oddly" do
+            assert_nil @sanitizer.sanitize!('Hello 41 11 11 11 11 11 11 11 there')
+          end
 
-        it "sanitizes amex card grouped 4-6-5" do
-          assert_equal 'Hello 3782 82▇▇▇▇ ▇0005 there', @sanitizer.sanitize!('Hello 3782 822463 10005 there')
-        end
+          it "sanitizes mastercard grouped 4-4-4-4" do
+            assert_equal 'Hello 5555 55▇▇ ▇▇▇▇ 4444 there', @sanitizer.sanitize!('Hello 5555 5555 5555 4444 there')
+          end
 
-        it "does not sanitize amex card grouped oddly" do
-          assert_nil @sanitizer.sanitize!('Hello 3782 8224 6310 005 there')
-        end
+          it "does not sanitize mastercard grouped oddly" do
+            assert_nil @sanitizer.sanitize!('Hello 55555 55555 554444 there')
+          end
 
-        it "sanitizes diners club grouped 4-6-4" do
-          assert_equal 'Hello 3056 93▇▇▇▇ 5904 there', @sanitizer.sanitize!('Hello 3056 930902 5904 there')
-        end
+          it "sanitizes amex card grouped 4-6-5" do
+            assert_equal 'Hello 3782 82▇▇▇▇ ▇0005 there', @sanitizer.sanitize!('Hello 3782 822463 10005 there')
+          end
 
-        it "does not sanitize diners club grouped oddly" do
-          assert_nil @sanitizer.sanitize!('Hello 3056 9309 0259 04 there')
-        end
+          it "does not sanitize amex card grouped oddly" do
+            assert_nil @sanitizer.sanitize!('Hello 3782 8224 6310 005 there')
+          end
 
-        it "sanitizes maestro if first group is 4 or 5 digits" do
-          assert_equal 'Hello 6799 99▇▇▇▇▇ ▇▇▇▇0 019 there', @sanitizer.sanitize!('Hello 6799 9901000 00000 019 there')
-          assert_equal 'Hello 67999 9▇▇▇▇▇ ▇▇▇▇0 019 there', @sanitizer.sanitize!('Hello 67999 901000 00000 019 there')
-        end
+          it "sanitizes diners club grouped 4-6-4" do
+            assert_equal 'Hello 3056 93▇▇▇▇ 5904 there', @sanitizer.sanitize!('Hello 3056 930902 5904 there')
+          end
 
-        it "does not sanitize maestro if first group is not 4 or 5 digits" do
-          assert_nil @sanitizer.sanitize!('Hello 679 99901000 00000 019 there')
-          assert_nil @sanitizer.sanitize!('Hello 67 999901000 00000 019 there')
-          assert_nil @sanitizer.sanitize!('Hello 679999 01000 00000 019 there')
+          it "does not sanitize diners club grouped oddly" do
+            assert_nil @sanitizer.sanitize!('Hello 3056 9309 0259 04 there')
+          end
+
+          it "sanitizes maestro if first group is 4 or 5 digits" do
+            assert_equal 'Hello 6799 99▇▇▇▇▇ ▇▇▇▇0 019 there', @sanitizer.sanitize!('Hello 6799 9901000 00000 019 there')
+            assert_equal 'Hello 67999 9▇▇▇▇▇ ▇▇▇▇0 019 there', @sanitizer.sanitize!('Hello 67999 901000 00000 019 there')
+          end
+
+          it "does not sanitize maestro if first group is not 4 or 5 digits" do
+            assert_nil @sanitizer.sanitize!('Hello 679 99901000 00000 019 there')
+            assert_nil @sanitizer.sanitize!('Hello 67 999901000 00000 019 there')
+            assert_nil @sanitizer.sanitize!('Hello 679999 01000 00000 019 there')
+          end
         end
       end
     end

--- a/test/credit_card_sanitizer_test.rb
+++ b/test/credit_card_sanitizer_test.rb
@@ -66,6 +66,11 @@ class CreditCardSanitizerTest < MiniTest::Test
         end
       end
 
+      it "doesn't fail if text is not utf-8 encoded" do
+        ascii_text = '41111111111111112'.force_encoding(Encoding::ASCII)
+        assert_nil @sanitizer.sanitize!(ascii_text)
+      end
+
       it "sanitizes credit card numbers separated by newlines" do
         assert_equal "4111 11▇▇ ▇▇▇▇ 1111 \n 4111 11▇▇ ▇▇▇▇ 1111", @sanitizer.sanitize!("4111 1111 1111 1111 \n 4111 1111 1111 1111")
       end

--- a/test/credit_card_sanitizer_test.rb
+++ b/test/credit_card_sanitizer_test.rb
@@ -102,7 +102,10 @@ class CreditCardSanitizerTest < MiniTest::Test
         assert_nil @sanitizer.sanitize!("blah blah  +4111111111111111.json")
         assert_nil @sanitizer.sanitize!("\"+4111111111111111\"")
         assert_nil @sanitizer.sanitize!("(+4111111111111111)")
-        assert_nil @sanitizer.sanitize!("&#43;4111111111111111")
+      end
+
+      it "does not sanitize numbers that include a numeric html entity" do
+        assert_nil @sanitizer.sanitize!("&#43; 1 936 321 1111")
       end
 
       it "does not mutate the text when there is a url" do

--- a/test/credit_card_sanitizer_test.rb
+++ b/test/credit_card_sanitizer_test.rb
@@ -90,6 +90,13 @@ class CreditCardSanitizerTest < MiniTest::Test
         assert_nil @sanitizer.sanitize!("(http://support.zendesk.com/tickets/4111111111111111)")
       end
 
+      it "does not sanitize credit card numbers that start with +" do
+        assert_nil @sanitizer.sanitize!("+4111111111111111")
+        assert_nil @sanitizer.sanitize!("blah blah  +4111111111111111.json")
+        assert_nil @sanitizer.sanitize!("\"+4111111111111111\"")
+        assert_nil @sanitizer.sanitize!("(+4111111111111111)")
+      end
+
       it "does not mutate the text when there is a url" do
         url = "http://support.zendesk.com/tickets/4111111111111111"
         assert_nil @sanitizer.sanitize!(url)

--- a/test/credit_card_sanitizer_test.rb
+++ b/test/credit_card_sanitizer_test.rb
@@ -118,6 +118,11 @@ class CreditCardSanitizerTest < MiniTest::Test
         assert_equal "4111 11▇▇ ▇▇▇▇ 1111 3-2015", @sanitizer.sanitize!("4111 1111 1111 1111 3-2015")
         assert_equal "4111 11▇▇ ▇▇▇▇ 1111 03-2015 asdbhasd", @sanitizer.sanitize!("4111 1111 1111 1111 03-2015 asdbhasd")
       end
+
+      it "does not sanitize a credit card number immediately followed by digits" do
+        assert_nil @sanitizer.sanitize!("41111111111111112")
+        assert_nil @sanitizer.sanitize!("411111111111111123456789")
+      end
     end
 
     describe "#parameter_filter" do

--- a/test/credit_card_sanitizer_test.rb
+++ b/test/credit_card_sanitizer_test.rb
@@ -95,6 +95,10 @@ class CreditCardSanitizerTest < MiniTest::Test
         assert_nil @sanitizer.sanitize!("4111,1111,1111,1111")
       end
 
+      it "does not sanitize a credit card number separated by periods" do
+        assert_nil @sanitizer.sanitize!("4111.1111.1111.1111")
+      end
+
       it "does not sanitize credit card numbers separated by parentheses" do
         assert_nil @sanitizer.sanitize!("(411)111-111111-1111")
       end

--- a/test/credit_card_sanitizer_test.rb
+++ b/test/credit_card_sanitizer_test.rb
@@ -97,6 +97,10 @@ class CreditCardSanitizerTest < MiniTest::Test
         assert_nil @sanitizer.sanitize!("(http://support.zendesk.com/tickets/4111111111111111)")
       end
 
+      it "does not sanitize credit card numbers that are part of an html tag" do
+        assert_nil @sanitizer.sanitize!('<a href="/tickets/40004595">#40004595</a>')
+      end
+
       it "does not sanitize credit card numbers that start with +" do
         assert_nil @sanitizer.sanitize!("+4111111111111111")
         assert_nil @sanitizer.sanitize!("blah blah  +4111111111111111.json")

--- a/test/credit_card_sanitizer_test.rb
+++ b/test/credit_card_sanitizer_test.rb
@@ -7,6 +7,14 @@ class CreditCardSanitizerTest < MiniTest::Test
       @sanitizer = CreditCardSanitizer.new
     end
 
+    describe "credit card patterns" do
+      it "CARD_NUMBER_GROUPINGS matches CARD_COMPANIES" do
+        a = CreditCardSanitizer::CARD_COMPANIES.keys
+        b = CreditCardSanitizer::CARD_NUMBER_GROUPINGS.keys
+        assert_equal [], (a - b) | (b - a)
+      end
+    end
+
     describe "#sanitize!" do
       it "sanitizes text keeping first 6 and last 4 digits by default" do
         assert_equal 'Hello 4111 11▇▇ ▇▇▇▇ 1111 there',     @sanitizer.sanitize!('Hello 4111 1111 1111 1111 there')

--- a/test/credit_card_sanitizer_test.rb
+++ b/test/credit_card_sanitizer_test.rb
@@ -30,6 +30,13 @@ class CreditCardSanitizerTest < MiniTest::Test
         assert_equal 'My cc is 411111▇▇▇▇▇▇1111, I repeat, 411111▇▇▇▇▇▇1111', @sanitizer.sanitize!('My cc is 4111111111111111, I repeat, 4111111111111111')
       end
 
+      it "finishes in a reasonable amount of time with spacey input" do
+        input = "Hello  0      0      0     14     20      1      1     20     34      9      1      0      0      0      0      0"
+        Timeout.timeout(3) do
+          assert_nil @sanitizer.sanitize!(input)
+        end
+      end
+
       it "has a configurable replacement character" do
         sanitizer = CreditCardSanitizer.new(replacement_token: '*')
         assert_equal 'Hello 4111 11**** **111 1 there', sanitizer.sanitize!('Hello 4111 111111 11111 1 there')

--- a/test/credit_card_sanitizer_test.rb
+++ b/test/credit_card_sanitizer_test.rb
@@ -8,7 +8,7 @@ class CreditCardSanitizerTest < MiniTest::Test
     end
 
     describe "credit card patterns" do
-      it "match between CARD_NUMBER_GROUPINGS and CARD_COMPANIES" do
+      it "should match between CARD_NUMBER_GROUPINGS and CARD_COMPANIES" do
         a = CreditCardSanitizer::CARD_COMPANIES.keys
         b = CreditCardSanitizer::CARD_NUMBER_GROUPINGS.keys
         assert_equal [], (a - b) | (b - a)

--- a/test/credit_card_sanitizer_test.rb
+++ b/test/credit_card_sanitizer_test.rb
@@ -8,7 +8,7 @@ class CreditCardSanitizerTest < MiniTest::Test
     end
 
     describe "credit card patterns" do
-      it "CARD_NUMBER_GROUPINGS matches CARD_COMPANIES" do
+      it "match between CARD_NUMBER_GROUPINGS and CARD_COMPANIES" do
         a = CreditCardSanitizer::CARD_COMPANIES.keys
         b = CreditCardSanitizer::CARD_NUMBER_GROUPINGS.keys
         assert_equal [], (a - b) | (b - a)
@@ -48,6 +48,10 @@ class CreditCardSanitizerTest < MiniTest::Test
       it "has a configurable replacement character" do
         sanitizer = CreditCardSanitizer.new(replacement_token: '*')
         assert_equal 'Hello 4111 11** **** 1111 there', sanitizer.sanitize!('Hello 4111 1111 1111 1111 there')
+      end
+
+      it "can configure replacement character on a per-call basis" do
+        assert_equal 'Hello 4111 11** **** 1111 there', @sanitizer.sanitize!('Hello 4111 1111 1111 1111 there', replacement_token: '*')
       end
 
       it "has configurable replacement digits" do
@@ -155,7 +159,7 @@ class CreditCardSanitizerTest < MiniTest::Test
       describe "card number grouping" do
         describe "use_groupings is false" do
           before do
-            refute @sanitizer.use_groupings
+            refute @sanitizer.settings[:use_groupings]
           end
 
           it "sanitizes cards grouped any which way" do

--- a/test/credit_card_sanitizer_test.rb
+++ b/test/credit_card_sanitizer_test.rb
@@ -102,6 +102,7 @@ class CreditCardSanitizerTest < MiniTest::Test
         assert_nil @sanitizer.sanitize!("blah blah  +4111111111111111.json")
         assert_nil @sanitizer.sanitize!("\"+4111111111111111\"")
         assert_nil @sanitizer.sanitize!("(+4111111111111111)")
+        assert_nil @sanitizer.sanitize!("&#43;4111111111111111")
       end
 
       it "does not mutate the text when there is a url" do


### PR DESCRIPTION
We have encountered instances of a number followed by whitespace followed by an IP address getting redacted, i.e. something of the form

`4111 111.111.111.111`

We believe that it is highly unusual for a credit card number to be separated by periods.

As such, to fix the above problem, we are removing `.` from the pattern for acceptable line noise between credit card digits.

/cc @kintner @jespr
